### PR TITLE
Create new Storage Class with "Retain" Reclaim Policy

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,55 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.45.1"
+  constraints = "~> 2.45.1"
+  hashes = [
+    "h1:fHWHWrf6l5P2IAYGPyt1trkeEwpSLwwK1+30EHNQplQ=",
+    "zh:257cc6e06e7b4f5eb7b8e5999ed59a984a16d2c7582da01c4318be4270d3274f",
+    "zh:49dffa76925d3db2634668630d5cdc33d80b7ffbdc39787b180ed41ee657a4fa",
+    "zh:6d1c28e9e35e7a6ff6a7ce57a5ffe34213c263ff135f2aa2900474f51568037b",
+    "zh:80c0f6c5e83ce57a08a8552b4b9b8b1f4d42a7bc3b050a408e003cbe20e55272",
+    "zh:9a30b2821d5ee4a7aa2145f6467639f414a5851e7c658346d57b94bde56c7ec4",
+    "zh:a6ba84564b768b821726fe2fc34763bece99e2ef190420a49e6c94e7a86d279e",
+    "zh:c32d250618b841aac2ef5c1af40d9f4d551162957d5f9c2106851e9363b37b4d",
+    "zh:cc4af260a0d017a6fcda436c8ddb9e5d049ec9a38d51d141498ebaeeadd1fa22",
+    "zh:e0cfe4d5a9a19d02ab19123ad9bccde8e0f87f130bd3d93760e651968f6da637",
+    "zh:e65803c7d2625ad2217543f177494b4fcb737c391e21649cfb167541aa9a9d64",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.0.2"
+  hashes = [
+    "h1:PRfDnUFBD4ud7SgsMAa5S2Gd60FeriD1PWE6EifjXB0=",
+    "zh:4e66d509c828b0a2e599a567ad470bf85ebada62788aead87a8fb621301dec55",
+    "zh:55ca6466a82f60d2c9798d171edafacc9ea4991aa7aa32ed5d82d6831cf44542",
+    "zh:65741e6910c8b1322d9aef5dda4d98d1e6409aebc5514b518f46019cd06e1b47",
+    "zh:79456ca037c19983977285703f19f4b04f7eadcf8eb6af21f5ea615026271578",
+    "zh:7c39ced4dc44181296721715005e390021770077012c206ab4c209fb704b34d0",
+    "zh:86856c82a6444c19b3e3005e91408ac68eb010c9218c4c4119fc59300b107026",
+    "zh:999865090c72fa9b85c45e76b20839da51714ae429d1ab14b7d8ce66c2655abf",
+    "zh:a3ea0ae37c61b4bfe81f7a395fb7b5ba61564e7d716d7a191372c3c983271d13",
+    "zh:d9061861822933ebb2765fa691aeed2930ee495bfb6f72a5bdd88f43ccd9e038",
+    "zh:e04adbe0d5597d1fdd4f418be19c9df171f1d709009f63b8ce1239b71b4fa45a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,10 @@ terraform {
             source  = "hashicorp/azurerm"
             version = "~> 2.45.1"
         }
+        kubernetes = {
+            source = "hashicorp/kubernetes"
+            version = ">= 2.0.2"
+        }
     }
 
     backend "azurerm" {
@@ -56,6 +60,14 @@ terraform {
         key                  = "kuksatrng.tfstate"
     }
 }
- provider "azurerm" {
-      features {}
-  }
+
+provider "azurerm" {
+    features {}
+}
+
+provider "kubernetes" {
+    host                   = module.k8s_cluster_azure.host
+    client_key             = base64decode(module.k8s_cluster_azure.client_key)
+    client_certificate     = base64decode(module.k8s_cluster_azure.client_certificate)
+    cluster_ca_certificate = base64decode(module.k8s_cluster_azure.cluster_ca_certificate)
+}

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
-
+locals {
+  project_name = terraform.workspace == "default" ? var.project_name : "${terraform.workspace}${var.project_name}"
+}
 
 # module "tfstate_storage_azure" {
 #     source  = "./modules/tfstate_storage_azure"
@@ -13,13 +15,13 @@ module "k8s_cluster_azure" {
     source = "./modules/k8s"
     k8s_agent_count = var.k8s_agent_count
     k8s_resource_group_name_suffix = var.k8s_resource_group_name_suffix
-    project_name = var.project_name
+    project_name = local.project_name
 }
 
 module "container_registry_for_k8s" {
     source = "./modules/container_registry"
     container_registry_resource_group_suffix = var.container_registry_resource_group_suffix
-    project_name = var.project_name
+    project_name = local.project_name
     k8s_cluster_node_resource_group = module.k8s_cluster_azure.k8s_cluster_node_resource_group
     k8s_cluster_kubelet_managed_identity_id = module.k8s_cluster_azure.kubelet_object_id
 }

--- a/modules/k8s/main.tf
+++ b/modules/k8s/main.tf
@@ -89,3 +89,16 @@ resource "azurerm_kubernetes_cluster" "k8s_cluster" {
         environment = var.environment
     }
 }
+
+resource "kubernetes_storage_class" "azure-disk-retain" {
+  metadata {
+    name = "azure-disk-retain"
+  }
+  storage_provisioner = "kubernetes.io/azure-disk"
+  reclaim_policy      = "Retain"
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    kind = "managed"
+    cachingMode = "ReadOnly"
+  }
+}


### PR DESCRIPTION
566a2ed : see pull request smaddis/smad-deploy-azure#21

9f75a30 : module "k8s" now creates a Storage Class with name "azure-disk-retain" that has a "Retain" Reclaim Policy. This means that the PV's created via PersistentVolumeClaims will not be deleted even though the PersistentVolumeClaim is deleted. 

Note that the default Storage Class still has Reclaim Policy of "Delete", you have to explicitly use the "azure-disk-retain" Storage Class. I think this is currently the preferred solution, since lingering PV's resulting from tests could result in additional costs? @hjhsalo 

closes smaddis/common-issues#30